### PR TITLE
moved locale settings from Jenkinsfile to tests script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ stages {
         }
     stage('Test rundoc') {
       steps {
-            sh " export LC_ALL=C.UTF-8 ; export LANG=C.UTF-8 ; export PATH=$PATH:~/.local/bin; ./tests/all.sh"
+            sh "export PATH=$PATH:~/.local/bin; ./tests/all.sh"
           }
         }
   } //stages

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -3,6 +3,9 @@
 
 set -e
 
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
 script_dir=$(cd `dirname "$0"`; pwd; cd - 2>&1 >> /dev/null)
 cd $script_dir
 


### PR DESCRIPTION
I moved these lines into `./tests/all.sh` because I need them there anyway. Tests are failing on public GitLab pipeline without them.
Also this leaves Jenkinsfile looking a bit cleaner.