### PR TITLE
Deprecation warning

### DIFF
--- a/rundoc/__init__.py
+++ b/rundoc/__init__.py
@@ -1,7 +1,7 @@
 """
 A command-line utility that runs code blocks from markdown files.
 """
-__version__ = "0.3.16"
+__version__ = "0.3.17"
 __license__ = "BSD"
 __year__ = "2017-2018"
 __author__ = "Predrag Mandic"

--- a/rundoc/commander.py
+++ b/rundoc/commander.py
@@ -230,8 +230,8 @@ class DocCommander(object):
                 self.write_output()
                 raise CodeFailed("Failed at step {} with exit code '{}'".format(
                         self.step, self.doc_block.last_run['retcode']))
-            print("{}Retry number {}.".format(
-                ansi.bold, len(self.doc_block.runs), ansi.end), end="")
+            print("{}Retry number {}/{}.".format(
+                ansi.bold, len(self.doc_block.runs), retry, ansi.end), end="")
             sleep(retry_pause)
         self.step = 0
         self.write_output()

--- a/rundoc/parsers.py
+++ b/rundoc/parsers.py
@@ -3,11 +3,11 @@ Tools for parsing markdown docs.
 """
 from bs4 import BeautifulSoup
 from collections import defaultdict
+from markdown_rundoc.rundoc_code import RundocCodeExtension
 from rundoc.block import DocBlock, block_actions
 from rundoc.commander import DocCommander
 import json
 import markdown
-import markdown_rundoc.rundoc_code
 import operator
 import re
 
@@ -17,8 +17,10 @@ def mkd_to_html(mkd, tags='', must_have_tags='', must_not_have_tags=''):
     html_data = markdown.markdown(
         mkd,
         extensions = [ 
-            'markdown_rundoc.rundoc_code(tags={},must_have_tags={}, must_not_have_tags={})'.format(
-                tags, must_have_tags, must_not_have_tags,
+            RundocCodeExtension(
+                tags=tags,
+                must_have_tags=must_have_tags,
+                must_not_have_tags=must_not_have_tags
                 )
             ]
         )


### PR DESCRIPTION
- Fixed deprecation warning with markdown 2.6 which would cause error in markdown 2.7.
- Printing max number of retries when code block fails and tries again.
- Version bump.